### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,5 @@ set -e
 
 pip3 install bandit=="${INPUT_BANDIT_VERSION}"
 
+# shellcheck disable=SC2086
 bandit ${INPUT_OPTIONS} ${INPUT_TARGETS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,4 @@ set -e
 
 pip3 install bandit=="${INPUT_BANDIT_VERSION}"
 
-bandit "$INPUT_OPTIONS" "$INPUT_PATH"
+bandit ${INPUT_OPTIONS} ${INPUT_TARGETS}


### PR DESCRIPTION
This PR tries to address this issue: https://github.com/tj-actions/bandit/issues/18
- Renamed `$INPUT_PATH` to `${INPUT_TARGETS}` to reflect the 1.3 -> 2.0 input renaming in the documentation
- Removed quotes around `$INPUT_OPTIONS` and `$INPUT_TARGETS` to allow specifying more than one value, as the input names being plural suggest